### PR TITLE
Update materialize-tags.js

### DIFF
--- a/src/materialize-tags.js
+++ b/src/materialize-tags.js
@@ -16,7 +16,7 @@
         addOnBlur       : true,
         maxTags         : undefined,
         maxChars        : undefined,
-        confirmKeys     : [9,13, 44],
+        confirmKeys     : [9,13, 44, 188],
         onTagExists     : onTagExists,
         trimValue       : true,
         allowDuplicates : false


### PR DESCRIPTION
Comma (keycode: 188) as a confirm key. Unfortunately, for some reasons keycode 44 for comma does not work.